### PR TITLE
set string instead of null

### DIFF
--- a/config/storyblok-cli.php
+++ b/config/storyblok-cli.php
@@ -10,7 +10,7 @@ return [
 	| Enter your Storyblok Personal access token to access their management API
 	|
 	*/
-	'oauth_token' => env('STORYBLOK_OAUTH_TOKEN', null),
+	'oauth_token' => env('STORYBLOK_OAUTH_TOKEN', ""),
 
 	/*
 	|--------------------------------------------------------------------------
@@ -20,5 +20,5 @@ return [
 	| Enter your Storyblok space ID for use with the management API
 	|
 	*/
-	'space_id' => env('STORYBLOK_SPACE_ID', null),
+	'space_id' => env('STORYBLOK_SPACE_ID', ""),
 ];


### PR DESCRIPTION
The installation of the package it fails if you don't already have your .env file. This because the Storyblok SDK accept only string and not null as token.